### PR TITLE
configurable unit name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To check your own passport, ACE-self-interact and go to *Equipment >> Check ID C
 # Implementation
 
 ## Personal Details (Variables)
-By default, every unit is assigned some random personal details (as soon as his passport is viewed for the first time). You can overwrite these if you like. All of these variables are saved in the unit and have the prefix `grad_passport_`. Data type of all variables has to be *STRING*.
+By default, every unit is assigned some random personal details (as soon as his passport is viewed for the first time). You can overwrite these if you like. All of these variables are saved in the unit and have the prefix `grad_passport_`. Data type of all variables has to be *STRING*. See [Available Properties](#available-properties) for all available variables.
 
 So for example if I wanted to set the date of birth for a unit, I would use:
 
@@ -95,7 +95,6 @@ To assign the custom passport to a unit you need:
 _unit setVariable ["grad_passport_passportRsc","myPassport"];
 ```
 
-
 ## Available Properties
 
 These are used in the default passport:
@@ -104,8 +103,8 @@ Usage                                                                          |
 -------------------------------------------------------------------------------|--------------|------
 **These are used in the default passport:**                                    |              |
 the dialog classname that this unit uses                                       | passportRsc  | -
-first name (taken from unit's identity)                                        | -            | 42001
-last name (taken from unit's identity)                                         | -            | 42001
+first name (default taken from unit's identity)                                | firstName    | 42001
+last name (default taken from unit's identity)                                 | lastName     | 42001
 date of birth                                                                  | dateOfBirth  | 42003
 place of birth                                                                 | placeOfBirth | 42004
 serial                                                                         | serial       | 42005

--- a/functions/fn_getPassportData.sqf
+++ b/functions/fn_getPassportData.sqf
@@ -6,6 +6,9 @@ params [["_passportOwner",objNull]];
 
 (([_passportOwner] call ace_common_fnc_getName) splitstring " ") params [["_firstName","--"],["_lastName","--"]];
 
+_firstName = _passportOwner getVariable [QGVAR(firstName), _firstName];
+_lastName = _passportOwner getVariable [QGVAR(lastName), _lastName];
+
 private _dateOfBirth = _passportOwner getVariable [QGVAR(dateOfBirth),""];
 if (_dateOfBirth == "") then {
     _currentYear = date select 0;


### PR DESCRIPTION
while there is "ACE_name" that can bet set, 
* it gets set automatically sometime during init *regardless of any previous value* - so would need to use some delay to set it. too hacky for my taste.
* afaics ACE_name was only a  workaround for arma not showing names of dead units, so might be subject to removal